### PR TITLE
locale param for relation_label closure

### DIFF
--- a/src/DsElasticSearchBundle/OutputChannel/Filter/AggregationFilter.php
+++ b/src/DsElasticSearchBundle/OutputChannel/Filter/AggregationFilter.php
@@ -162,7 +162,7 @@ class AggregationFilter implements FilterInterface
 
             $relationLabel = null;
             if ($this->options['relation_label'] !== null) {
-                $relationLabel = call_user_func($this->options['relation_label'], $bucket['key']);
+                $relationLabel = call_user_func($this->options['relation_label'], $bucket['key'], $queryFields['locale'] ?? null);
             } else {
                 $relationLabel = $bucket['key'];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This change would allow to build relation labels based on the locale of the current search query.
